### PR TITLE
chore: optimize backend Dockerfile for faster builds and correct gradlew usage

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -15,9 +15,9 @@ COPY backend/gradlew.bat ./gradlew.bat
 # Make gradlew executable
 RUN chmod +x ./gradlew
 
+
 # Download dependencies (for better caching)
 RUN ./gradlew dependencies --no-daemon --build-cache
-COPY backend/gradlew ./gradlew
 # Now copy the rest of the backend source
 COPY backend/. .
 

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -4,32 +4,37 @@ FROM openjdk:21-jdk-slim AS build
 # Set working directory
 WORKDIR /app
 
-# Copy entire backend directory for correct context
-COPY backend/. .
 
-# Debug: List all files after copy
-RUN ls -lR /app
+
+# Copy only Gradle build files and wrapper for dependency caching
+COPY backend/build.gradle.kts backend/settings.gradle.kts backend/gradle.properties ./
+COPY backend/gradle ./gradle
+COPY backend/gradlew ./gradlew
+COPY backend/gradlew.bat ./gradlew.bat
 
 # Make gradlew executable
 RUN chmod +x ./gradlew
 
 # Download dependencies (for better caching)
-RUN ./gradlew dependencies --no-daemon
+RUN ./gradlew dependencies --no-daemon --build-cache
+COPY backend/gradlew ./gradlew
+# Now copy the rest of the backend source
+COPY backend/. .
 
-# Force compilation before building the JAR
-RUN ./gradlew compileKotlin --no-daemon --stacktrace --info
-RUN ls -lR /app/build/ || true
+## Debug: List all files after copy
+# RUN ls -lR /app
 
-# Build the application (ensure fat JAR is created)
-RUN ./gradlew jar --no-daemon --stacktrace --info
-RUN ls -lR /app/build/ || true
-RUN find /app -name '*.jar' || true
-RUN cat /app/build/reports/* || true
+ # Make gradlew executable
+RUN chmod +x ./gradlew
 
-# Print Gradle tasks and source sets for debugging
-RUN echo "=== WHOAMI ===" && whoami
-RUN echo "=== GRADLE TASKS ===" && ./gradlew tasks --all --no-daemon > gradle_tasks.txt 2>&1 && cat gradle_tasks.txt
-RUN echo "=== PRINT SOURCE SET ===" && ./gradlew printSourceSet --no-daemon --stacktrace --info > gradle_sourceset.txt 2>&1 && cat gradle_sourceset.txt || true
+
+# Build the application (ensure fat JAR is created, skip tests for speed)
+RUN ./gradlew clean build -x test --no-daemon --build-cache --parallel
+
+## Print Gradle tasks and source sets for debugging
+# RUN echo "=== WHOAMI ===" && whoami
+# RUN echo "=== GRADLE TASKS ===" && ./gradlew tasks --all --no-daemon > gradle_tasks.txt 2>&1 && cat gradle_tasks.txt
+# RUN echo "=== PRINT SOURCE SET ===" && ./gradlew printSourceSet --no-daemon --stacktrace --info > gradle_sourceset.txt 2>&1 && cat gradle_sourceset.txt || true
 
 # Runtime stage
 FROM openjdk:21-jdk-slim


### PR DESCRIPTION
This PR optimizes the backend Dockerfile for faster builds and corrects gradlew usage:
- Copies only Gradle build files and wrapper first for better dependency caching
- Ensures gradlew is present and executable before running Gradle commands
- Copies the rest of the backend source after dependencies are cached
- Uses build cache and parallelism for faster builds

No application logic is changed. Safe for review and merge.